### PR TITLE
No new wallet on crash

### DIFF
--- a/apps/blockchain/README.md
+++ b/apps/blockchain/README.md
@@ -44,7 +44,7 @@ Data will be broadcasted on the network so nodes can start to mine it (i.e: comp
 Blockchain.connect("host:port")
 
 # list direct peers
-Blockchain.list_peers()
+Blockchain.peers()
 
 # add data to the blockchain. It will appear once mined
 Blockchain.add("some data")

--- a/apps/token/lib/token/application.ex
+++ b/apps/token/lib/token/application.ex
@@ -8,7 +8,7 @@ defmodule Token.Application do
   def start(_type, _args) do
     # Define workers and child supervisors to be supervised
     children = [
-      Token.MyWallet
+      {Token.MyWallet, Token.Wallet.generate_wallet()}
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/token/lib/token/application.ex
+++ b/apps/token/lib/token/application.ex
@@ -8,7 +8,7 @@ defmodule Token.Application do
   def start(_type, _args) do
     # Define workers and child supervisors to be supervised
     children = [
-      {Token.MyWallet, Token.Wallet.generate_wallet()}
+      {Token.MyWallet, Token.Wallet.generate()}
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/token/lib/token/my_wallet.ex
+++ b/apps/token/lib/token/my_wallet.ex
@@ -6,12 +6,12 @@ defmodule Token.MyWallet do
 
   alias Token.Wallet
 
-  def start_link(_opts) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  def start_link(%Wallet{} = w) do
+    GenServer.start_link(__MODULE__, w, name: __MODULE__)
   end
 
-  def init(_) do
-    {:ok, Wallet.generate_wallet()}
+  def init(%Wallet{} = w) do
+    {:ok, w}
   end
 
   @spec address() :: String.t()

--- a/apps/token/lib/token/wallet.ex
+++ b/apps/token/lib/token/wallet.ex
@@ -17,8 +17,8 @@ defmodule Token.Wallet do
     :private_key
   ]
 
-  @spec generate_wallet() :: t
-  def generate_wallet do
+  @spec generate() :: t
+  def generate do
     {pub, priv} = Crypto.generate_key_pair()
 
     %Wallet{

--- a/apps/token/lib/token/wallet.ex
+++ b/apps/token/lib/token/wallet.ex
@@ -85,9 +85,9 @@ defmodule Token.Wallet do
   end
 
   @spec select_outputs([Ledger.output()], integer, [Ledger.output()]) ::
-          {:ok, [Transaction.output()]} | {:error, String.t()}
+          {:ok, [Transaction.output()]} | {:error, atom()}
   defp select_outputs(_, value, outputs) when value <= 0, do: {:ok, outputs}
-  defp select_outputs([], _value, _outputs), do: {:error, "not enough coins"}
+  defp select_outputs([], _value, _outputs), do: {:error, :not_enough_coins}
 
   defp select_outputs([{_, _, v} = output | remaining], value, outputs) do
     select_outputs(remaining, value - v, [output | outputs])

--- a/apps/token/test/support/fixtures.ex
+++ b/apps/token/test/support/fixtures.ex
@@ -26,9 +26,9 @@ defmodule Token.Fixtures do
     :ok = Blockchain.clear()
 
     # create wallets for each participants
-    alice = Wallet.generate_wallet()
-    bob = Wallet.generate_wallet()
-    joe = Wallet.generate_wallet()
+    alice = Wallet.generate()
+    bob = Wallet.generate()
+    joe = Wallet.generate()
 
     # initial founds
     alice_utx = Transaction.new_coinbase_transaction([[alice.address, 50]])

--- a/apps/token/test/token/transaction/transaction_test.exs
+++ b/apps/token/test/token/transaction/transaction_test.exs
@@ -5,8 +5,8 @@ defmodule Token.TransactionTest do
 
   setup do
     {:ok, %{
-      alice: Wallet.generate_wallet(),
-      bob: Wallet.generate_wallet()
+      alice: Wallet.generate(),
+      bob: Wallet.generate()
     }}
   end
 

--- a/apps/token/test/token/wallet_test.exs
+++ b/apps/token/test/token/wallet_test.exs
@@ -8,11 +8,11 @@ defmodule Token.WalletTest do
     if tags[:mock_ledger] do
       {:ok, mock_ledger()}
     else
-      {:ok, wallet: Wallet.generate_wallet()}
+      {:ok, wallet: Wallet.generate()}
     end
   end
 
-  test "generate wallet", %{wallet: w} do
+  test "generate", %{wallet: w} do
     assert w.public_key != nil
     assert w.private_key != nil
     assert byte_size(w.address) == 40

--- a/apps/token/test/token/wallet_test.exs
+++ b/apps/token/test/token/wallet_test.exs
@@ -116,5 +116,7 @@ defmodule Token.WalletTest do
     assert b6 == b5 + amount
     # 29
     assert j6 == j5 - amount
+
+    assert Wallet.send(a6 + 1, bob.address, alice) == {:error, :not_enough_coins}
   end
 end


### PR DESCRIPTION
Fix the bug described in this issue: https://github.com/robinmonjo/coincoin/issues/21

No persistent wallet yet. I cleaned up a bit the `Wallet` and fix an error that was still expressed as a string and not as atom ...